### PR TITLE
✨ CustomException 구축

### DIFF
--- a/src/main/java/com/anywhere/somewhere/common/exception/custom/CustomException.java
+++ b/src/main/java/com/anywhere/somewhere/common/exception/custom/CustomException.java
@@ -1,0 +1,34 @@
+package com.anywhere.somewhere.common.exception.custom;
+
+import lombok.Getter;
+
+@Getter
+public abstract class CustomException extends RuntimeException {
+
+    private final ErrorType errorType;
+    private ErrorData errorData;
+
+    public CustomException(
+            ErrorCode errorCode
+    ) {
+        super(errorCode.getMessage());
+        this.errorType = errorCode;
+    }
+
+    public CustomException(
+            ErrorCode errorCode,
+            String message
+    ) {
+        super(errorCode.changeMessage(message).getMessage());
+        this.errorType = errorCode.changeMessage(message);
+    }
+
+    public CustomException(
+            ErrorCode errorCode,
+            ErrorData errorData
+    ) {
+        super(errorCode.getMessage());
+        this.errorType = errorCode;
+        this.errorData = errorData;
+    }
+}

--- a/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorCode.java
+++ b/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.anywhere.somewhere.common.exception.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode implements ErrorType{
+
+    SUCCESS(HttpStatus.OK, "200", "OK"),
+
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "404", "데이터 검증 실패"),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus statusCode;
+    private final String code;
+    private String message;
+
+    ErrorCode(
+            HttpStatus statusCode,
+            String code,
+            String message
+    ) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    public ErrorResult changeMessage(
+            String message
+    ) {
+        return new ErrorResult(this.statusCode, this.getCode(), message);
+    }
+}

--- a/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorData.java
+++ b/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorData.java
@@ -1,0 +1,4 @@
+package com.anywhere.somewhere.common.exception.custom;
+
+public interface ErrorData {
+}

--- a/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorResult.java
+++ b/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorResult.java
@@ -1,0 +1,18 @@
+package com.anywhere.somewhere.common.exception.custom;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ErrorResult implements ErrorType{
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    public ErrorResult(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorType.java
+++ b/src/main/java/com/anywhere/somewhere/common/exception/custom/ErrorType.java
@@ -1,0 +1,12 @@
+package com.anywhere.somewhere.common.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorType {
+
+    HttpStatus getStatusCode();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/anywhere/somewhere/common/exception/handler/ExceptionControllerAdvice.java
+++ b/src/main/java/com/anywhere/somewhere/common/exception/handler/ExceptionControllerAdvice.java
@@ -1,0 +1,47 @@
+package com.anywhere.somewhere.common.exception.handler;
+
+import com.anywhere.somewhere.common.exception.custom.CustomException;
+import com.anywhere.somewhere.common.exception.custom.ErrorCode;
+import com.anywhere.somewhere.common.response.ApiResponse;
+import com.anywhere.somewhere.common.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Slf4j
+@ControllerAdvice
+public class ExceptionControllerAdvice {
+
+    @ResponseBody
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<?> customExceptionHandler(
+            HttpServletResponse response, CustomException e
+    ) {
+        response.setStatus(e.getErrorType().getStatusCode().value());
+        log.error(e.getMessage());
+        return new ErrorResponse(e.getErrorType(), e.getErrorData());
+    }
+
+    @ResponseBody
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> validationHandler(
+            HttpServletResponse response, MethodArgumentNotValidException e
+    ) {
+        response.setStatus(ErrorCode.INVALID_FORMAT.getStatusCode().value());
+        String errorMessage = validationErrorMessage(e.getBindingResult().getFieldError());
+        log.error(errorMessage);
+        return new ErrorResponse(ErrorCode.INVALID_FORMAT.changeMessage(errorMessage));
+    }
+
+    private String validationErrorMessage(FieldError fieldError) {
+        if (fieldError != null) {
+            return fieldError.getDefaultMessage();
+        }
+        return ErrorCode.INVALID_FORMAT.getMessage();
+    }
+
+}


### PR DESCRIPTION


## [✨ ErrorType Interface 생성](https://github.com/Dongjin113/Some-Where-BE/commit/61b1470b23068e01e09c1c4e997314bfa9eb6b7c) 

### ErrorType Interface
- ErrorCode와 ErrorResult의 statusCode, code, message를 부모 인터페이스를 통해 가져와서 타입을 유연하게 사용하기 위해 생성



## [✨ ErrorData Interface 생성](https://github.com/Dongjin113/Some-Where-BE/commit/6bba5319775cfc3975335a091259baa6c0fab436) 

### ErrorData Interface
- 에러에 대한 추가적인 메시지 정보를 보내줄 클래스를 생성할때 부모인터페이스로 사용하기위해 구축


## [✨ ErrorResult 생성](https://github.com/Dongjin113/Some-Where-BE/commit/9794101999a437b85cdd804b0940329ef48e6390) 

### ErrorResult
- ErrorCode에서 선언한 message를 변경 시 EnumType이기 때문에 선언해둔 메시지가 영구적으로 변경되는 버그를 방지하기위해 메시지 변경시 메시지만 변경한 ErrorResult라는 새로운 객체를 만들어서 보내기 위해 생성


## [✨ ErrorCode EnumClass 생성](https://github.com/Dongjin113/Some-Where-BE/commit/eab448476632df5db24a435b93e347231fdcf154) 

### ErrorCode
- CustomException의 Http 상태코드, 직접 지정한 상태코드, 상태 메시지를 지정해둔 Class


## [✨ CustomException 생성](https://github.com/Dongjin113/Some-Where-BE/commit/eaf8f944012d1873be4a05e621c07ae746a2bb0b) 

### CustomException
- RuntimeException 에러들을 Custom 하기 위한 추상 클래스

#### 세가지 타입
- [ ] ErrorCode 에서 선언해둔 message와 errorCode를 클라이언트에 반환
- [ ] ErrorCode 에서 선언해둔 message만을 변경해서 클라이언트에 반환
- [ ] ErrorCode 에서 선언해둔 message와 errorCode를 반환하고 추가적으로 Error에 대한 데이터를 반환


## [✨ ExceptionControllerAdvice 구축](https://github.com/Dongjin113/Some-Where-BE/commit/bad22ac7b96b55b2e4e8c88a07a943bf7a793c14)
- 에러를 핸들링해 클라이언트에 반환하기 위한 클래스 

#### customExceptionHandler
- 선언해둔 CustomException 핸들링하기 위함
- error 발생 시 errormessage log로 남김

#### validationHandler
- 요청이 들어올 때 validation을 통해 검증 중 발생하는 에러를 핸들링 

## 
- close #1 
