### PR TITLE
✨ 지도 범위 내의 캠핑장 조회 해오기

### DIFF
--- a/src/main/docs/asciidoc/index.adoc
+++ b/src/main/docs/asciidoc/index.adoc
@@ -8,4 +8,22 @@
 지역을 통해 캠핑장을 검색해옵니다.
 
 include::{snippets}/camping-preview/path-parameters.adoc[]
-include::{snippets}/camping-preview/http-response.adoc[]
+include::{snippets}/camping-preview/response-fields.adoc[]
+include::{snippets}/camping-preview/response-body.adoc[]
+
+=== 지역별 캠핑장 수 조회
+지역별 캠핑장 수를 검색해옵니다.
+
+URL 요청 주소: `GET /api/camping/region/counts`
+
+include::{snippets}/camping-region-counts/response-fields.adoc[]
+include::{snippets}/camping-region-counts/response-body.adoc[]
+
+=== 위도 경도 범위내의 캠핑장 조회
+지역별 캠핑장 수를 검색해옵니다.
+
+URL 요청 주소: `GET /api/camping/location?northLng=200&southLng=0&eastLat=200&westLat=0`
+
+include::{snippets}/camping-location-preview/query-parameters.adoc[]
+include::{snippets}/camping-location-preview/response-fields.adoc[]
+include::{snippets}/camping-location-preview/response-body.adoc[]

--- a/src/main/java/com/some/where/camping/controller/CampingController.java
+++ b/src/main/java/com/some/where/camping/controller/CampingController.java
@@ -1,5 +1,6 @@
 package com.some.where.camping.controller;
 
+import com.some.where.camping.dto.request.LocationRequest;
 import com.some.where.camping.dto.response.CampingRegionCountsResponse;
 import com.some.where.camping.dto.response.CampingPreViewResponse;
 import com.some.where.camping.service.CampingService;
@@ -41,6 +42,20 @@ public class CampingController {
     ) {
         return new ApiResponse<>(
                 ErrorCode.SUCCESS, campingService.campingCountsByRegion()
+        );
+    }
+
+    /**
+     * 일정 위도 경도 범위내의 캠핑장 정보 받아오기
+     * @param locationRequest 북서, 동남의 위도와 경도
+     */
+    @GetMapping("/location")
+    private ApiResponse<List<CampingPreViewResponse>> findCampingByLocation(
+            @ModelAttribute LocationRequest locationRequest
+    ) {
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                campingService.findCampingByLocation(locationRequest)
         );
     }
 }

--- a/src/main/java/com/some/where/camping/dto/AddressDto.java
+++ b/src/main/java/com/some/where/camping/dto/AddressDto.java
@@ -1,0 +1,24 @@
+package com.some.where.camping.dto;
+
+import com.some.where.domain.embedded.Address;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AddressDto {
+
+    private String region;
+    private String city;
+    private Integer postNum;
+    private String roadAddress;
+    private String address;
+
+    public AddressDto(Address address) {
+        this.region = address.getRegion().getRegionName();
+        this.city = address.getCity();
+        this.postNum = address.getPostNum();
+        this.roadAddress = address.getRoadAddress();
+        this.address = address.getAddress();
+    }
+}

--- a/src/main/java/com/some/where/camping/dto/request/LocationRequest.java
+++ b/src/main/java/com/some/where/camping/dto/request/LocationRequest.java
@@ -1,0 +1,26 @@
+package com.some.where.camping.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LocationRequest {
+
+    private double northLng;
+
+    private double southLng;
+
+    private double eastLat;
+
+    private double westLat;
+
+    public LocationRequest(double northLng, double southLng, double eastLat, double westLat) {
+        this.northLng = northLng;
+        this.southLng = southLng;
+        this.eastLat = eastLat;
+        this.westLat = westLat;
+    }
+}

--- a/src/main/java/com/some/where/camping/dto/response/CampingPreViewResponse.java
+++ b/src/main/java/com/some/where/camping/dto/response/CampingPreViewResponse.java
@@ -1,11 +1,15 @@
 package com.some.where.camping.dto.response;
 
+import com.some.where.camping.dto.AddressDto;
 import com.some.where.domain.camping.Camping;
-import com.some.where.domain.embedded.Address;
+import com.some.where.domain.camping.CampingCategory;
 import com.some.where.domain.embedded.Location;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -13,16 +17,18 @@ public class CampingPreViewResponse {
 
     private Long campingId;
     private String placeName;
-    private Address address;
+    private AddressDto address;
     private Location location;
     private String phoneNum;
     private String homePage;
     private String subIntro;
+    private List<String> categories = new ArrayList<>();
 
     @Builder
     public CampingPreViewResponse(
-            Long campingId, String placeName, Address address,
-            Location location, String phoneNum, String homePage, String subIntro
+            Long campingId, String placeName, AddressDto address,
+            Location location, String phoneNum, String homePage,
+            String subIntro, List<String> categories
     ) {
         this.campingId = campingId;
         this.placeName = placeName;
@@ -31,17 +37,22 @@ public class CampingPreViewResponse {
         this.phoneNum = phoneNum;
         this.homePage = homePage;
         this.subIntro = subIntro;
+        this.categories = categories;
     }
 
-    public static CampingPreViewResponse of(Camping camping) {
+    public static CampingPreViewResponse of(Camping camping, List<CampingCategory> categories) {
+        List<String> categoryList = new ArrayList<>();
+        categories.forEach(campingCategory -> categoryList.add(campingCategory.getCategory().getName()));
+
         return CampingPreViewResponse.builder()
                 .campingId(camping.getId())
                 .placeName(camping.getPlaceName())
-                .address(camping.getAddress())
+                .address(new AddressDto(camping.getAddress()))
                 .location(camping.getLocation())
                 .phoneNum(camping.getPhoneNum())
                 .homePage(camping.getHomePage())
                 .subIntro(camping.getSubIntro())
+                .categories(categoryList)
                 .build();
     }
 

--- a/src/main/java/com/some/where/camping/repository/CampingRepository.java
+++ b/src/main/java/com/some/where/camping/repository/CampingRepository.java
@@ -16,4 +16,11 @@ public interface CampingRepository extends JpaRepository<Camping, Long>, Camping
 
     @Query("select new com.some.where.camping.dto.response.CampingRegionCountsResponse(c.address.region, Count(c))  from Camping c group by c.address.region")
     List<CampingRegionCountsResponse> findGroupByAddressRegionCounts();
+
+    @Query("""
+            select distinct c from Camping c 
+            left join fetch c.campingCategories 
+            where c.location.lat BETWEEN :westLat AND :eastLat 
+            And c.location.lng BETWEEN :southLng AND :northLng """)
+    List<Camping> findAllByLocation(@Param("westLat") double westLat, @Param("eastLat") double eastLat, @Param("northLng") double northLng, @Param("southLng") double southLng);
 }

--- a/src/main/java/com/some/where/camping/service/CampingService.java
+++ b/src/main/java/com/some/where/camping/service/CampingService.java
@@ -1,5 +1,6 @@
 package com.some.where.camping.service;
 
+import com.some.where.camping.dto.request.LocationRequest;
 import com.some.where.camping.dto.response.CampingRegionCountsResponse;
 import com.some.where.camping.dto.response.CampingPreViewResponse;
 import com.some.where.camping.repository.*;
@@ -43,5 +44,22 @@ public class CampingService {
     @Transactional(readOnly = true)
     public List<CampingRegionCountsResponse> campingCountsByRegion() {
         return campingRepository.findGroupByAddressRegionCounts();
+    }
+
+    /**
+     * 동서남북 위도와 경도를 통해서
+     * 해당 범위내의 캠핑장을 검색해서 반환
+     *
+     * @param locationRequest
+     */
+    @Transactional(readOnly = true)
+    public List<CampingPreViewResponse> findCampingByLocation(LocationRequest locationRequest) {
+        return campingRepository.findAllByLocation(
+                        locationRequest.getWestLat(), locationRequest.getEastLat(),
+                        locationRequest.getNorthLng(), locationRequest.getSouthLng()
+                ).stream()
+                .map(camping -> CampingPreViewResponse.of(
+                        camping, camping.getCampingCategories()))
+                .toList();
     }
 }

--- a/src/main/java/com/some/where/domain/camping/CampingCategory.java
+++ b/src/main/java/com/some/where/domain/camping/CampingCategory.java
@@ -2,6 +2,7 @@ package com.some.where.domain.camping;
 
 import com.some.where.domain.enums.CampingCategoryMenu;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,10 @@ public class CampingCategory {
 
     @Enumerated(STRING)
     private CampingCategoryMenu category;
+
+    @Builder
+    public CampingCategory(Camping camping, CampingCategoryMenu category) {
+        this.camping = camping;
+        this.category = category;
+    }
 }

--- a/src/test/java/com/some/where/camping/controller/CampingControllerTest.java
+++ b/src/test/java/com/some/where/camping/controller/CampingControllerTest.java
@@ -142,4 +142,70 @@ class CampingControllerTest extends ControllerTest {
                                 fieldWithPath("data[0].lng").description("경도")
                         )));
     }
+
+    @Test
+    @DisplayName("일정 위도 경도 범위내의 캠핑장 정보 받아오기")
+    void findCampingByLocation() throws Exception {
+
+        List<CampingCategory> campingCategories = Arrays.asList(
+                CampingCategory.builder().category(CampingCategoryMenu.일반야영장).build(),
+                CampingCategory.builder().category(CampingCategoryMenu.글램핑).build(),
+                CampingCategory.builder().category(CampingCategoryMenu.카라반).build()
+        );
+
+        List<CampingPreViewResponse> campingList = IntStream.range(0, 3).mapToObj(
+                index -> CampingPreViewResponse.of(
+                        new Camping("서울캠핑장" + index,
+                                new Location(13.12, 12.12),
+                                new Address(Region.서울특별시, "강서구", 1235, "도로명", "주소"),
+                                "홈페이지 URL", "사유지",
+                                "12-123-1234", "서브소개", "소개"
+                        ), campingCategories)).toList();
+
+        when(campingService.findCampingByLocation(any())).thenReturn(campingList);
+
+        mockMvc.perform(get("/api/camping/location?northLng=200&southLng=0&eastLat=200&westLat=0")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(jsonPath("$.status.code").value("200"))
+                .andExpect(jsonPath("$.status.message").value("OK"))
+                .andExpect(jsonPath("$.data[0].placeName").value("서울캠핑장0"))
+                .andExpect(jsonPath("$.data[0].location.lat").value(13.12))
+                .andExpect(jsonPath("$.data[0].location.lng").value(12.12))
+                .andExpect(jsonPath("$.data[0].address.region").value("서울"))
+                .andExpect(jsonPath("$.data[0].address.city").value("강서구"))
+                .andExpect(jsonPath("$.data[0].address.postNum").value(1235))
+                .andExpect(jsonPath("$.data[0].address.roadAddress").value("도로명"))
+                .andExpect(jsonPath("$.data[0].address.address").value("주소"))
+                .andExpect(jsonPath("$.data[0].homePage").value("홈페이지 URL"))
+                .andExpect(jsonPath("$.data[0].phoneNum").value("12-123-1234"))
+                .andExpect(jsonPath("$.data[0].subIntro").value("서브소개"))
+                .andDo(
+                        document("camping-location-preview",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                queryParameters(
+                                        parameterWithName("northLng").description("북쪽 경도"),
+                                        parameterWithName("southLng").description("남쪽 경도"),
+                                        parameterWithName("eastLat").description("동쪽 위도"),
+                                        parameterWithName("westLat").description("서쪽 위도")
+                                ),
+                                responseFields(
+                                        fieldWithPath("status.code").description("상태 코드"),
+                                        fieldWithPath("status.message").description("상태 메시지"),
+                                        fieldWithPath("data[0].campingId").description("캠핑장 id값"),
+                                        fieldWithPath("data[0].placeName").description("캠핑장 이름"),
+                                        fieldWithPath("data[0].location.lat").description("위도"),
+                                        fieldWithPath("data[0].location.lng").description("경도"),
+                                        fieldWithPath("data[0].address.region").description("지역"),
+                                        fieldWithPath("data[0].address.city").description("군,구"),
+                                        fieldWithPath("data[0].address.postNum").description("우편 번호"),
+                                        fieldWithPath("data[0].address.roadAddress").description("도로명 주소"),
+                                        fieldWithPath("data[0].address.address").description("지번 주소"),
+                                        fieldWithPath("data[0].homePage").description("캠핑장 홈페이지"),
+                                        fieldWithPath("data[0].phoneNum").description("캠핑장 번호"),
+                                        fieldWithPath("data[0].subIntro").description("캠핑장 간단 소개"),
+                                        fieldWithPath("data[0].categories").description("캠핑장 카테고리")
+                                ))
+                );
+    }
 }

--- a/src/test/java/com/some/where/camping/service/CampingServiceTest.java
+++ b/src/test/java/com/some/where/camping/service/CampingServiceTest.java
@@ -1,5 +1,6 @@
 package com.some.where.camping.service;
 
+import com.some.where.camping.dto.request.LocationRequest;
 import com.some.where.camping.dto.response.CampingRegionCountsResponse;
 import com.some.where.camping.dto.response.CampingPreViewResponse;
 import com.some.where.camping.repository.CampingCategoryRepository;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTest
+@Transactional
 class CampingServiceTest {
 
     @Autowired
@@ -40,7 +42,6 @@ class CampingServiceTest {
 
     @BeforeEach
     void beforeTest() {
-
         List<Camping> campingList = IntStream.range(0, 10).mapToObj(
                 index -> new Camping("서울캠핑장" + index,
                         new Location(13.12, 12.12),
@@ -58,7 +59,6 @@ class CampingServiceTest {
     }
 
     @Test
-    @Transactional
     @DisplayName("캠핑장 데이터 지역으로 조회하기")
     void campingPreviewList() {
         //when
@@ -66,7 +66,6 @@ class CampingServiceTest {
 
         //then
         assertThat(result.size()).isEqualTo(10);
-        assertThat(result.get(0).getCampingId()).isEqualTo(1);
         assertThat(result.get(0).getPlaceName()).isEqualTo("서울캠핑장0");
         assertThat(result.get(0).getAddress().getRegion()).isEqualTo("서울");
         assertThat(result.get(0).getAddress().getCity()).isEqualTo("강서구");
@@ -78,5 +77,16 @@ class CampingServiceTest {
         List<CampingRegionCountsResponse> result = campingService.campingCountsByRegion();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getCampingCounts()).isEqualTo(10);
+    }
+
+
+    @Test
+    @DisplayName("위도 경도 범위안의 캠핑장 검색")
+    public void findCampingByLocation() {
+        LocationRequest location = new LocationRequest(200, 0, 200, 0);
+        List<CampingPreViewResponse> campingByLocation = campingService.findCampingByLocation(location);
+
+        assertThat(campingByLocation.size()).isEqualTo(10);
+
     }
 }


### PR DESCRIPTION
# [♻️ Address Region Enum 타입으로 변경함에 의한 Dto Response 수정](https://github.com/Dongjin113/Some-Where-BE/commit/11de565165fee42fcda548f89eeddd9b68cfba9e) 
## CampingPreViewResponse
- FetchJoin으로 받아온 Category를 응답값에 추가

## AddressDto
- UI의 지역명과 DB의 지역명이 다르게 표시됨으로 Enum 타입을 통해 변경하여 사용


# [✨ 지도 화면 범위 내의 캠핑장 조회 해오기](https://github.com/Dongjin113/Some-Where-BE/commit/700b6232e268e3089274d75e72bbdda614f2a751) 
## LocationRequest
- QueryString으로 받아오는 북서, 동남 위도 경도를 담는 Request 객체

## CampingRepository
- 지도 범위내의 캠핑장 데이터 조회시 중복데이터 제거를 위해 distinct 사용
- JPQL을 이용하여 fetchJoin 사용해 category 같이 조회 시 N+1 문제를 해결

## CampingService
- 지도 범위 내의 캠핑장 검색 기능 추가
- DB에서 조회해온 데이터를 Response 객체로 변경할 때 정잭 팩토리 메서드 패턴을 사용하여 가독성 개선

## CampingController
- 지도 범위내의 캠핑장 수 검색 api 추가
- 북서, 동남 쪽의 위도경도 받아 옴


# [✅ 지도범위 내의 캠핑장 조회 단위 테스트](https://github.com/Dongjin113/Some-Where-BE/commit/51206f23a8187c6124f466ea090c4cca77c6ce6d) 
 ## CampingServiceTest
- 지도범위 내의 캠핑장 조회 단위 테스트


# [✅ 지도범위 내의 캠핑장 조회 통합 테스트](https://github.com/Dongjin113/Some-Where-BE/commit/ed055084c8686331415207c31b203804d85d3425) 
 ## CampingControllerTest
- 지도범위 내의 캠핑장 조회 통합 테스트 추가
- SpringRestDoc을 통한 문서화

